### PR TITLE
updated to not use deprecated prog_–types

### DIFF
--- a/Gamby.cpp
+++ b/Gamby.cpp
@@ -280,7 +280,7 @@ void GambyBase::setColumn (byte column) {
  * @param icon: The icon's location in `PROGMEM` (e.g. the name of the 
  *    `PROGMEM` constant).
  */
-void GambyBase::drawIcon(const prog_uchar *icon) {
+void GambyBase::drawIcon(const unsigned char *icon) {
   DATA_MODE();
   byte w = pgm_read_byte_near(icon);
   currentColumn += w;
@@ -297,7 +297,7 @@ void GambyBase::drawIcon(const prog_uchar *icon) {
  *    `PROGMEM` constant).
  * @param frame  The frame number, 0 to (total frames)-1
  */
-void GambyBase::drawIcon(const prog_uchar *icon, byte frame) {
+void GambyBase::drawIcon(const unsigned char *icon, byte frame) {
   DATA_MODE();
   byte w = pgm_read_byte_near(icon);
   icon += w * frame;
@@ -316,7 +316,7 @@ void GambyBase::drawIcon(const prog_uchar *icon, byte frame) {
  * @param frame  The frame number, 0 to (total frames)-1
  * @param transform  The transform to apply, `HFLIP` and/or `VFLIP`
  */
-void GambyBase::drawIcon(const prog_uchar *icon, byte frame, byte transform) {
+void GambyBase::drawIcon(const unsigned char *icon, byte frame, byte transform) {
   DATA_MODE();
   byte w = pgm_read_byte_near(icon);
   currentColumn += w;
@@ -1185,7 +1185,7 @@ boolean GambyGraphicsMode::getPatternPixel (byte x, byte y) {
  * @param x  The sprite's horizontal position
  * @param y  The sprite's vertical position
  */
-void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite) {
+void GambyGraphicsMode::drawSprite(byte x, byte y, const unsigned char *sprite) {
   byte w = pgm_read_byte_near(sprite);
   byte h = pgm_read_byte_near(++sprite);
 
@@ -1216,7 +1216,7 @@ void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite) {
  *     constant's name) 
  * @param frame The frame number to draw (0 to (number of frames)-1)
  */
-void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite, byte frame) {
+void GambyGraphicsMode::drawSprite(byte x, byte y, const unsigned char *sprite, byte frame) {
   unsigned int w = pgm_read_byte_near(sprite);
   unsigned int h = pgm_read_byte_near(++sprite);
 
@@ -1258,7 +1258,7 @@ void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite, byt
  * @param mask: The address of the mask sprite in `PROGMEM` 
  *     (e.g. the constant's name) 
  */
-void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite, const prog_uchar *mask) {
+void GambyGraphicsMode::drawSprite(byte x, byte y, const unsigned char *sprite, const unsigned char *mask) {
   byte w = pgm_read_byte_near(sprite);
   byte h = pgm_read_byte_near(++sprite);
 
@@ -1299,8 +1299,8 @@ void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite, con
  * @param maskFrame The mask image's frame number to draw 
  *     (0 to (number of frames)-1)
  */
-void GambyGraphicsMode::drawSprite(byte x, byte y, const prog_uchar *sprite, byte frame, 
-				   const prog_uchar *mask, byte maskFrame) {
+void GambyGraphicsMode::drawSprite(byte x, byte y, const unsigned char *sprite, byte frame, 
+				   const unsigned char *mask, byte maskFrame) {
   byte w = pgm_read_byte_near(sprite);
   byte h = pgm_read_byte_near(++sprite);
 

--- a/Gamby.h
+++ b/Gamby.h
@@ -249,9 +249,9 @@ class GambyBase {
   byte getCharBaseline(byte);
   int getTextWidth(char *);
   int getTextWidth_P(const char *);
-  void drawIcon(const prog_uchar *);
-  void drawIcon(const prog_uchar *, byte);
-  void drawIcon(const prog_uchar *, byte, byte);
+  void drawIcon(const unsigned char *);
+  void drawIcon(const unsigned char *, byte);
+  void drawIcon(const unsigned char *, byte, byte);
   void drawChar(char);
   void print(char *);
   void print(long, uint8_t = 10);
@@ -279,7 +279,7 @@ class GambyBase {
   static byte inputs;            /**< The D-Pad and button states. Set by readInputs(). */
   static byte textDraw;
 
-  const prog_int32_t* font; /**< The font to be used for drawing text, read from PROGMEM. */
+  const int32_t* font; /**< The font to be used for drawing text, read from PROGMEM. */
 
   // private:
   byte currentPage;
@@ -331,7 +331,7 @@ class GambyBlockMode: public GambyBase {
   void update();
   void update(byte, byte, byte, byte);
 
-  const prog_uint16_t* palette; /**< The palette of 16 4x4 pixel blocks */
+  const uint16_t* palette; /**< The palette of 16 4x4 pixel blocks */
   byte offscreen[NUM_BLOCK_COLUMNS][NUM_PAGES]; /**< The offscreen buffer, where the screen is stored before being drawn */
 
 };
@@ -358,10 +358,10 @@ class GambyGraphicsMode: public GambyBase {
   void circle(int, int, int);
   void disc(int, int, int);
 
-  void drawSprite(byte, byte, const prog_uchar *);
-  void drawSprite(byte, byte, const prog_uchar *, const prog_uchar *);
-  void drawSprite(byte, byte, const prog_uchar *, byte);
-  void drawSprite(byte, byte, const prog_uchar *, byte, const prog_uchar *, byte);
+  void drawSprite(byte, byte, const unsigned char *);
+  void drawSprite(byte, byte, const unsigned char *, const unsigned char *);
+  void drawSprite(byte, byte, const unsigned char *, byte);
+  void drawSprite(byte, byte, const unsigned char *, byte, const unsigned char *, byte);
 
   void drawText(int, int, char *);
   void drawText_P(int, int, const char *);


### PR DESCRIPTION
“The usage of the **progmem** attribute on a type is not supported in GCC. However, the use of the **progmem** attribute on a variable declaration is supported, and this is now the recommended usage.”

http://www.atmel.no/webdoc/AVRLibcReferenceManual/group__avr__pgmspace_1ga7d4701843a2019e3ef5a9866dc7586ed.html
